### PR TITLE
Python as in python2

### DIFF
--- a/assignment4/Makefile
+++ b/assignment4/Makefile
@@ -9,10 +9,10 @@ zip:
 config: web/config.php paper/config.h
 
 %/config.php: config.ini
-	python confgen.py php $@
+	python2 confgen.py php $@
 
 %/config.h: config.ini
-	python confgen.py c $@
+	python2 confgen.py c $@
 
 web/smarty:
 	make -C web smarty

--- a/assignment4/confgen.py
+++ b/assignment4/confgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import ConfigParser, os, sys
 


### PR DESCRIPTION
not every distro has python2 as default python interpreter.
Archlinux has python3 as default for quite some years.
