### PR TITLE
Fix wrong link description

### DIFF
--- a/assignment4/web/tpl/index.html
+++ b/assignment4/web/tpl/index.html
@@ -62,7 +62,7 @@
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Hotel <span class="caret"></span></a>
                         <ul class="dropdown-menu">
                             <li><a href="hotellist.php">Available Rooms</a></li>
-                            <li><a href="hotelbook.php">Paper List</a></li>
+                            <li><a href="hotelbook.php">Book Room</a></li>
                             <li><a href="participants.php">Look who's coming!</a></li>
 
                         </ul>


### PR DESCRIPTION
One of the dropdown actions for 'Hotel' has the wrong name. It appears to be copy & pasted from the 'Paper' menu, and wrongly reads "Paper List", while it should be "Book Room".

This was also reported as a comment in Pull Request #2.
